### PR TITLE
Make it easier to download

### DIFF
--- a/components/MarketingServerMono.tsx
+++ b/components/MarketingServerMono.tsx
@@ -9,6 +9,9 @@ import { H3, P, Title, SubText } from '@system/typography';
 
 export default function MarketingServerMono(props) {
   const videoUrl = 'https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/2316285a-4e2e-4f39-b578-1b0c9cdb7e93.mp4';
+  const releaseUrl = 'https://github.com/internet-development/www-server-mono/releases';
+  const releaseDate = '1-1-2025';
+  const releaseVersion = '0.0.6';
 
   return (
     <>
@@ -44,8 +47,8 @@ export default function MarketingServerMono(props) {
         <div className={styles.row}>
           <div className={styles.content}>
             <Title>Downloads</Title>
-            <ActionItem style={{ marginTop: `1rem` }} icon={`⊹`} href="https://github.com/internet-development/www-server-mono/blob/main/fonts" target="_blank">
-              [0.0.6] [1-1-2025] Latest release
+            <ActionItem style={{ marginTop: `1rem` }} icon={`⊹`} href={releaseUrl} target="_blank">
+              [{releaseVersion}] [{releaseDate}] Latest release
             </ActionItem>
             <ActionItem icon={`⭢`} href="https://github.com/internet-development/www-server-mono" target="_blank">
               View repository on GitHub


### PR DESCRIPTION
Opinionated fix, feel free to close if you prefer to point to the repo files.

Currently the release link on the homepage points to the directory of raw files in the repo. This makes it difficult to download the font files in a single click for installing locally. You have to click through to each file on Github, and then click the download link, and then go install locally.

This PR changes the link to point to the releases page instead, where the download link to a zip of the latest release is right there at the top.

Downside: Your release zip has the entire website in it. Would be nice to have a GHA that zips just the font files when a release is cut. This PR does not do that. But the approach in this PR does make it easier to download the font files in one shot from the homepage, compared to how it is now.

(Also constantize some in-content values while we're there.)