### PR TITLE
Release v0.1.0

### DIFF
--- a/components/MarketingServerMono.tsx
+++ b/components/MarketingServerMono.tsx
@@ -11,7 +11,7 @@ export default function MarketingServerMono(props) {
   const videoUrl = 'https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/2316285a-4e2e-4f39-b578-1b0c9cdb7e93.mp4';
   const releaseUrl = 'https://github.com/internet-development/www-server-mono/releases';
   const releaseDate = '06-20-2025';
-  const releaseVersion = '0.0.8';
+  const releaseVersion = '0.1.0';
 
   return (
     <>

--- a/components/MarketingServerMono.tsx
+++ b/components/MarketingServerMono.tsx
@@ -10,7 +10,7 @@ import { H3, P, Title, SubText } from '@system/typography';
 export default function MarketingServerMono(props) {
   const videoUrl = 'https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/2316285a-4e2e-4f39-b578-1b0c9cdb7e93.mp4';
   const releaseUrl = 'https://github.com/internet-development/www-server-mono/releases';
-  const releaseDate = '06-20-2025';
+  const releaseDate = '07-12-2025';
   const releaseVersion = '0.1.0';
 
   return (

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=18"
   },
   "license": "MIT",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "jsdelivr": "./server-mono.css",
   "scripts": {
     "dev": "next -p 10000",


### PR DESCRIPTION
This pull request updates the release information and versioning for the `MarketingServerMono` component and its associated package. The changes primarily reflect a version bump and an updated release date.

Release information updates:

* [`components/MarketingServerMono.tsx`](diffhunk://#diff-1ae34da450f6e78b0dfff619e68847845a541d075577c97dd41655788d5ddd42L13-R14): Updated the `releaseDate` to `07-12-2025` and the `releaseVersion` to `0.1.0` to reflect the new release details.

Versioning updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8): Updated the `version` field to `0.1.0` to match the new release version.